### PR TITLE
Fix overriding Intl in docs on Rails usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,21 +88,16 @@ Further complicating matters, `jstz` uses the forward-thinking `window.Intl`, wh
 
 ```js
 export function findTimeZone() {
-  // Because Intl is considered read-only and enforced on Android Chrome, we use Object.defineProperty to get around
   const oldIntl = window.Intl
-  Object.defineProperty(window, 'Intl', {
-    get() {},
-  })
-
-  // get the timezone...
-  const tz = jstz.determine().name()
-
-  // return Intl to original functionality
-  Object.defineProperty(window, 'Intl', {
-    get() { return oldIntl },
-  })
-
-  return tz
+  try {
+    window.Intl = undefined
+    const tz = jstz.determine().name()
+    window.Intl = oldIntl
+    return tz
+  } catch (e) {
+    // sometimes (on android) you can't override intl
+    return jstz.determine().name()
+  }
 }
 ```
 


### PR DESCRIPTION
Apparently iOS complains when you use `Object.defineProperty` to override `Intl`. There doesn't seem to be a good way to force it, so just wrap the operation in a `try` block and default to original behavior when it fails.

I've also heard that [Intl actually does play nicely with Rails](https://github.com/kbaum/browser-timezone-rails/pull/37#issuecomment-308348196), I still need to do some research there, but in the mean time I wanted to fix the docs so it's not putting out code that will bust on some browsers.