### PR TITLE
rails example in readme needs a symbol not a string to access the cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This method could go on your base application controller, assuming you're settin
 ```ruby
 # Returns the client's time zone based on a cookie set by the browser, defaults to application time zone
 def browser_time_zone
-  browser_tz = ActiveSupport::TimeZone.find_tzinfo(cookies['browser_time_zone'])
+  browser_tz = ActiveSupport::TimeZone.find_tzinfo(cookies[:browser_time_zone])
   ActiveSupport::TimeZone.all.find { |zone| zone.tzinfo == browser_tz } || Time.zone
 rescue TZInfo::UnknownTimezone, TZInfo::InvalidTimezoneIdentifier
   Time.zone


### PR DESCRIPTION
Using a string in `cookies['browser_time_zone']` returns nothing. Switching to a symbol like `cookies[:browser_time_zone]` retrieves the cookie value.