### PR TITLE
Return Standard TimezoneOffset

### DIFF
--- a/jstz.main.js
+++ b/jstz.main.js
@@ -394,6 +394,14 @@ var jstz = (function () {
             return {
                 name: function () {
                     return preliminary_tz;
+                },
+                stdTimezoneOffset : function () {
+                    // negative to match what (new Date).getTimezoneOffset() will return
+                    return -lookup_key().split(',')[0]
+                },
+                timezoneOffset : function () {
+                    // negative to match what (new Date).getTimezoneOffset() will return
+                    return -get_date_offset(new Date)
                 }
             };
         };

--- a/test.js
+++ b/test.js
@@ -15,5 +15,16 @@ describe('API', function() {
     expect(timezone).to.respondTo('name');
     expect(timezone.name()).to.be.a('string');
   });
+  it('Timezone instance has an stdTimezoneOffset method that returns a number', function() {
+    var timezone = jstz.determine();
+    expect(timezone).to.respondTo('stdTimezoneOffset');
+    expect(timezone.stdTimezoneOffset()).to.be.a('number');
+  });
+  
+  it('Timezone instance has a timezoneOffset method that returns a number', function() {
+    var timezone = jstz.determine();
+    expect(timezone).to.respondTo('timezoneOffset');
+    expect(timezone.timezoneOffset()).to.be.a('number');
+  });
 });
 

--- a/test.js
+++ b/test.js
@@ -20,7 +20,6 @@ describe('API', function() {
     expect(timezone).to.respondTo('stdTimezoneOffset');
     expect(timezone.stdTimezoneOffset()).to.be.a('number');
   });
-  
   it('Timezone instance has a timezoneOffset method that returns a number', function() {
     var timezone = jstz.determine();
     expect(timezone).to.respondTo('timezoneOffset');


### PR DESCRIPTION
I believe there might be people out there who would need to return Standard Timezone Offset. This was a need for me, leading to this addition I'm suggesting here. 
I also added the `timezoneOffset` field to return the timezone so the developer/user can see if the user is on DST or not.